### PR TITLE
Use system compiler linux

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -16,7 +16,11 @@ else
     CXX=g++
     WITH_OPENMP=ON
 
-    ILASTIKTOOLS_CXXFLAGS="${CFLAGS} -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0"
+    ILASTIKTOOLS_CXXFLAGS="${CFLAGS} -std=c++11"
+    # enable compilation without CXX abi to stay compatible with gcc < 5 built packages
+    if [[ ${DO_NOT_BUILD_WITH_CXX11_ABI} == '1' ]]; then
+        ILASTIKTOOLS_CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${ILASTIKTOOLS_CXXFLAGS}"
+    fi
 fi
 
 PY_VER=$(python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -12,11 +12,11 @@ if [[ $(uname) == 'Darwin' ]]; then
     ILASTIKTOOLS_CXXFLAGS="${CFLAGS} -std=c++11 -stdlib=libc++"
 else
     DYLIB_EXT=so
-    CC=${PREFIX}/bin/gcc
-    CXX=${PREFIX}/bin/g++
+    CC=gcc
+    CXX=g++
     WITH_OPENMP=ON
 
-    ILASTIKTOOLS_CXXFLAGS="${CFLAGS} -std=c++11"
+    ILASTIKTOOLS_CXXFLAGS="${CFLAGS} -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0"
 fi
 
 PY_VER=$(python -c "import sys; print('{}.{}'.format(*sys.version_info[:2]))")

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,6 +20,9 @@ build:
   msvc_compiler: 14.0 # [win]
   number: 0
   string: np{{np}}py{{py}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
+  script_env:
+    # Control building with CXX11 abi
+    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 requirements:
   build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,6 @@ build:
 
 requirements:
   build:
-    - gcc 4.8.5 # [linux]
     - python 2.7*|3.5*|3.6*
     - python {{PY_VER}}*
     - numpy {{NPY_VER}}*
@@ -31,7 +30,6 @@ requirements:
     - boost 1.63.0
 
   run:
-    - libgcc 4.8.5 # [linux]
     - python {{PY_VER}}*
     - numpy  {{NPY_VER}}*
     - vigra 1.11*

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
   features:
     - vc14 # [win]
   msvc_compiler: 14.0 # [win]
-  number: 0
+  number: 1
   string: np{{np}}py{{py}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
   script_env:
     # Control building with CXX11 abi


### PR DESCRIPTION
This is related to allowing dependencies to be built with newer gcc than the one available through conda (4.8.5 atm), in particular, recent nifty changes forced us to use a newer compiler.

See some more background on this in https://github.com/ilastik/ilastik-publish-packages/issues/2

In order to use the system compilers this PR removes

* references to `gcc`, `libgcc` in the respective `meta.yaml` files
* points to the correct compiler in `build.sh`
* introduces an environment variable `DO_NOT_BUILD_WITH_CXX11_ABI` that is used in the build process to enable building with `-D_GLIBCXX_USE_CXX11_ABI=0` to enable compatibility with the "old" gcc stdlib abi.