### PR TITLE
Make setSeeds write the correct value for foreground and background labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,9 @@
 *.out
 *.app
 
-# Misc IDE files
+# IDE files
 .cproject
 .project
 .settings
+.idea/
+*.iml

--- a/include/ilastiktools/carving.hxx
+++ b/include/ilastiktools/carving.hxx
@@ -499,7 +499,7 @@ namespace vigra{
                     c[dd] = bgSeedsCoord(dd,i);
                 }
                 const UInt64 node = labels[c];
-                nodeSeeds_[node] = 2;
+                nodeSeeds_[node] = 1;
             }
         }
 


### PR DESCRIPTION
A bug discovered while fixing https://github.com/ilastik/ilastik/issues/2627

This bug doesn't have any effect. setSeeds is only used in the carving workflow when re-loading a previously segmented and saved object. `opCarving.loadObject()` uses setSeeds to reintroduce the loaded labels to the operator's backend, but then converts the restored labels into brushstrokes and reapplies them as user input (opCarving.WriteSeeds). This (setInSlot) reintroduces the labels both into the front- and backend; in the latter it overwrites the values wrongly written by setSeeds with addSeeds.

So also this fix is quiet, it will have no effect. But next time we come back to the Carving workflow, this allows us to either use setSeeds as it was intended, or decide to abandon the function entirely (and deprecate it in ilastiktools).

To clarify why we would abandon it: setSeeds doesn't actually save the operator any work right now. Converting the loaded labels into brushstrokes is required anyway so that they can be displayed in the frontend. We could write extra fuctionality so that loadObject can circumvent the WriteSeeds input slot and reintroduce the loaded labels in backend and frontend without converting them to brushstrokes. But the performance gain to be expected is probably negligible, and only relevant when users load objects (which should be a sort of niche thing to happen). So low prio, or not even worth the additional code complexity.